### PR TITLE
copy workflows move to file in the github

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,7 @@
+name: 'Continuous Delivery'
+
+on:
+  ...
+
+jobs:
+  ...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,7 @@
+name: 'Continuous Integration'
+
+on:
+  ...
+
+jobs:
+  ...


### PR DESCRIPTION
The new folder called `.github` was created and the files were copied from the `workflows` folder